### PR TITLE
Optionally use libWrapper for patching

### DIFF
--- a/moulinette-compendiums.js
+++ b/moulinette-compendiums.js
@@ -37,25 +37,48 @@ Hooks.once("ready", async function () {
     console.log("Moulinette Compendiums | Module loaded")
   }
 
+  const isLibwrapperAvailable = typeof libWrapper === "function"; // See: https://github.com/ruipin/fvtt-lib-wrapper
+
   // replace default FVTT implementation for Items
-  Item.implementation.fromDropDataOrig = Item.implementation.fromDropData
-  Item.implementation.fromDropData = async function(data, options={}) { 
-    await MoulinetteCompendiumsCloudUtil.handleDragAndDrop(data)
-    return await Item.implementation.fromDropDataOrig(data, options)
+  if (isLibwrapperAvailable) {
+    libWrapper.register("moulinette-compendiums", "Item.implementation.fromDropData", async (wrapped, ...args) => {
+      await MoulinetteCompendiumsCloudUtil.handleDragAndDrop(args[0])
+      return wrapped(...args);
+    }, "WRAPPER");
+  } else {
+    Item.implementation.fromDropDataOrig = Item.implementation.fromDropData
+    Item.implementation.fromDropData = async function(data, options={}) {
+      await MoulinetteCompendiumsCloudUtil.handleDragAndDrop(data)
+      return await Item.implementation.fromDropDataOrig(data, options)
+    }
   }
 
   // replace default FVTT implementation for Macros
-  Macro.implementation.fromDropDataOrig = Macro.implementation.fromDropData
-  Macro.implementation.fromDropData = async function(data, options={}) { 
-    await MoulinetteCompendiumsCloudUtil.handleDragAndDrop(data)
-    return await Macro.implementation.fromDropDataOrig(data, options)
+  if (isLibwrapperAvailable) {
+    libWrapper.register("moulinette-compendiums", "Macro.implementation.fromDropData", async (wrapped, ...args) => {
+      await MoulinetteCompendiumsCloudUtil.handleDragAndDrop(args[0])
+      return wrapped(...args);
+    }, "WRAPPER");
+  } else {
+    Macro.implementation.fromDropDataOrig = Macro.implementation.fromDropData
+    Macro.implementation.fromDropData = async function(data, options={}) {
+      await MoulinetteCompendiumsCloudUtil.handleDragAndDrop(data)
+      return await Macro.implementation.fromDropDataOrig(data, options)
+    }
   }
 
   // replace default FVTT implementation for JournalEntry
-  JournalEntry.implementation.fromDropDataOrig = JournalEntry.implementation.fromDropData
-  JournalEntry.implementation.fromDropData = async function(data, options={}) { 
-    await MoulinetteCompendiumsCloudUtil.handleDragAndDrop(data)
-    return await JournalEntry.implementation.fromDropDataOrig(data, options)
+  if (isLibwrapperAvailable) {
+    libWrapper.register("moulinette-compendiums", "JournalEntry.implementation.fromDropData", async (wrapped, ...args) => {
+      await MoulinetteCompendiumsCloudUtil.handleDragAndDrop(args[0])
+      return wrapped(...args);
+    }, "WRAPPER");
+  } else {
+    JournalEntry.implementation.fromDropDataOrig = JournalEntry.implementation.fromDropData
+    JournalEntry.implementation.fromDropData = async function(data, options={}) {
+      await MoulinetteCompendiumsCloudUtil.handleDragAndDrop(data)
+      return await JournalEntry.implementation.fromDropDataOrig(data, options)
+    }
   }
 });
 


### PR DESCRIPTION
The libWrapper module provides an API for patching methods in a way which promotes cross-module compatibility. If the user has libWrapper active, prefer its patching methods, falling back on manual patching if the module is unavailable.

See: https://github.com/ruipin/fvtt-lib-wrapper

---

(Note that these branches could all be pruned by declaring a direct module dependency on libWrapper, which is a very popular module: ![badge](https://img.shields.io/badge/dynamic/json?label=Forge%20Installs&query=package.installs&suffix=%25&url=https%3A%2F%2Fforge-vtt.com%2Fapi%2Fbazaar%2Fpackage%2Flib-wrapper&colorB=4aa94a) )